### PR TITLE
getdate function added

### DIFF
--- a/jdatetime.class.php
+++ b/jdatetime.class.php
@@ -410,6 +410,54 @@ class jDateTime
         //Return
         return $ret;
     }
+    
+    /**
+     * jDateTime::getdate
+     *
+     * Like php built-in function, returns an associative array containing the date information of a timestamp.
+     *
+     * @author Meysam Pour Ganji
+     * @param $timestamp int The timestamp that whould convert to date information array, if NULL passed, current timestamp will be processed.
+     * @return An associative array of information related to the timestamp. For see elements of the returned associative array see {@link http://php.net/manual/en/function.getdate.php#refsect1-function.getdate-returnvalues}.
+     */
+    public static function getdate( $timestamp = NULL )
+    {
+    	if( $timestamp === NULL )
+    	{
+    		$timestamp = time();
+    	}
+    	
+       	if( is_string($timestamp) )
+    	{
+    		if( ctype_digit($timestamp) || ( $timestamp{0} == '-' && ctype_digit(substr($timestamp, 1)) ) )
+    		{
+    			$timestamp = (int)$timestamp;
+    		}
+    		else
+    		{
+    			$timestamp = strtotime($timestamp);
+    		}
+    	}
+    	
+    	$dateString = self::date("s|i|G|j|w|n|Y|z|l|F", $timestamp);
+    	$dateArray = explode("|", $dateString);
+    	
+    	$result = array(
+    			"seconds" => $dateArray[0],
+    			"minutes" => $dateArray[1],
+    			"hours" => $dateArray[2],
+    			"mday" => $dateArray[3],
+    			"wday" => $dateArray[4],
+    			"mon" => $dateArray[5],
+    			"year" => $dateArray[6],
+    			"yday" => $dateArray[7],
+    			"weekday" => $dateArray[8],
+    			"month" => $dateArray[9],
+    			0 => $timestamp
+    		); 
+    	
+    	return $result;
+    }
 
     /**
      * System Helpers below

--- a/jdatetime.class.php
+++ b/jdatetime.class.php
@@ -414,49 +414,49 @@ class jDateTime
     /**
      * jDateTime::getdate
      *
-     * Like php built-in function, returns an associative array containing the date information of a timestamp.
+     * Like php built-in function, returns an associative array containing the date information of a timestamp, or the current local time if no timestamp is given. .
      *
      * @author Meysam Pour Ganji
      * @param $timestamp int The timestamp that whould convert to date information array, if NULL passed, current timestamp will be processed.
      * @return An associative array of information related to the timestamp. For see elements of the returned associative array see {@link http://php.net/manual/en/function.getdate.php#refsect1-function.getdate-returnvalues}.
      */
-    public static function getdate( $timestamp = NULL )
+    public static function getdate($timestamp = null)
     {
-    	if( $timestamp === NULL )
-    	{
-    		$timestamp = time();
-    	}
-    	
-       	if( is_string($timestamp) )
-    	{
-    		if( ctype_digit($timestamp) || ( $timestamp{0} == '-' && ctype_digit(substr($timestamp, 1)) ) )
-    		{
-    			$timestamp = (int)$timestamp;
-    		}
-    		else
-    		{
-    			$timestamp = strtotime($timestamp);
-    		}
-    	}
-    	
-    	$dateString = self::date("s|i|G|j|w|n|Y|z|l|F", $timestamp);
-    	$dateArray = explode("|", $dateString);
-    	
-    	$result = array(
-    			"seconds" => $dateArray[0],
-    			"minutes" => $dateArray[1],
-    			"hours" => $dateArray[2],
-    			"mday" => $dateArray[3],
-    			"wday" => $dateArray[4],
-    			"mon" => $dateArray[5],
-    			"year" => $dateArray[6],
-    			"yday" => $dateArray[7],
-    			"weekday" => $dateArray[8],
-    			"month" => $dateArray[9],
-    			0 => $timestamp
-    		); 
-    	
-    	return $result;
+        if ( $timestamp === null )
+        {
+            $timestamp = time();
+        }
+        
+        if ( is_string($timestamp) )
+        {
+            if( ctype_digit($timestamp) || ( $timestamp{0} == '-' && ctype_digit(substr($timestamp, 1)) ) )
+            {
+                $timestamp = (int)$timestamp;
+            }
+            else
+            {
+                $timestamp = strtotime($timestamp);
+            }
+        }
+        
+        $dateString = self::date("s|i|G|j|w|n|Y|z|l|F", $timestamp);
+        $dateArray = explode("|", $dateString);
+        
+        $result = array(
+            "seconds" => $dateArray[0],
+            "minutes" => $dateArray[1],
+            "hours" => $dateArray[2],
+            "mday" => $dateArray[3],
+            "wday" => $dateArray[4],
+            "mon" => $dateArray[5],
+            "year" => $dateArray[6],
+            "yday" => $dateArray[7],
+            "weekday" => $dateArray[8],
+            "month" => $dateArray[9],
+            0 => $timestamp
+        ); 
+        
+        return $result;
     }
 
     /**


### PR DESCRIPTION
`getdate(null|int timestamp|string datetime) : array` function added. This function return an array contains information of given timestamp. For example, `getdate()` will return an array like this:
```
array(11) {
  ["seconds"]=>
  string(4) "۳۱"
  ["minutes"]=>
  string(4) "۰۳"
  ["hours"]=>
  string(4) "۱۰"
  ["mday"]=>
  string(4) "۱۶"
  ["wday"]=>
  string(2) "۱"
  ["mon"]=>
  string(4) "۱۲"
  ["year"]=>
  string(8) "۱۳۹۴"
  ["yday"]=>
  string(6) "۳۵۲"
  ["weekday"]=>
  string(12) "یکشنبه"
  ["month"]=>
  string(10) "اسفند"
  [0]=>
  int(1457246011)
}
```
This function maybe useful in situations like populating of a timeline of messages that can reduce using of `date` function significantly.