### PR TITLE
mktime function time parameters NULL bug fixed

### DIFF
--- a/Tests/JDateTimeTest.php
+++ b/Tests/JDateTimeTest.php
@@ -19,6 +19,8 @@ class JDateTimeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($time, 630361800);
         $this->assertEquals($this->obj->date("l Y/m/d", $time), "شنبه ۱۳۶۸/۱۰/۰۲");
         $this->assertEquals($this->obj->date("c", $time, false), "1368-10-02T00:00:00+03:30");
+        $time = $this->obj->mktime(NULL, NULL, NULL, 10, 14, 1395);
+        $this->assertEquals($time, 1483389000);
     }
 
     public function testMakeGregorianTime()

--- a/jdatetime.class.php
+++ b/jdatetime.class.php
@@ -373,6 +373,9 @@ class jDateTime
         $month = (intval($month) == 0) ? self::date('m') : $month;
         $day   = (intval($day)   == 0) ? self::date('d') : $day;
         $year  = (intval($year)  == 0) ? self::date('Y') : $year;
+        $hour  = intval($hour);
+        $minute  = intval($minute);
+        $second  = intval($second);
 
         //Convert to Gregorian if necessary
         if ( $jalali === true || ($jalali === null && self::$jalali === true) ) {


### PR DESCRIPTION
I know this package is deprecated, but as you know as long as it is in packagist.org too many old projects are depending on this.
there was a bug in mktime function, when you set hour, minute or second to NULL, you will see this error: 

> DateTime::__construct(): Failed to parse time string (2017-01-03 ::) at position 11 (:): Unexpected character
#0 sallar/jdatetime/jdatetime.class.php(389): DateTime->__construct('2017-01-03 ::', Object(DateTimeZone))

so I added 3 intval() function for hour, minute and second to fix this bug.