### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ UNMAINTAINED
 
 :round_pushpin: If you happen to be a php developer and want to maintain this project, please give me a shout so I can give you write access to this project.
 
-#jDateTime
+# jDateTime
 
 PHP class to convert dates from Gregorian calendar system to Jalali calendar system and vice versa. Supports dates beyond 2038.  
 Jalali, also known as Shamsi or Hijri Shamsi is the Iranian calendar system.  
 [![Build Status](https://travis-ci.org/sallar/jDateTime.png?branch=master)](https://travis-ci.org/sallar/jDateTime)
 
-#About v2.2.0
+# About v2.2.0
 
 PHP's default `date` function does not support years higher than 2038, so the `DateTime` class was introduced in PHP5 to solve this problem and provide more sophisticated date methods. Iranian users have been using an old `jdate` function to convert Gregorian date to the Jalali equivalent, which is completely based on the old php `date` function so its pretty much out-dated. 
 
-#Requirements
+# Requirements
 
 jDateTime Requires **PHP >= 5.2**  
 
-#Installation
+# Installation
 
-##Using Composer
+## Using Composer
 
 You can install this package using [composer](https://getcomposer.org). Add this package to your `composer.json`:  
 
@@ -36,7 +36,7 @@ or if you prefer command line, change directory to project root and:
 php composer.phar require "sallar/jdatetime":"dev-master"
 ```
 
-##Manual Installation
+## Manual Installation
 
 Get a copy of package source code. You can do this in two ways:
 
@@ -49,18 +49,18 @@ After getting a copy of source code, it is enough to include `jdatetime.class.ph
 require_once 'path/to/source/jdatetime.class.php';
 ```
 
-#Examples
+# Examples
 
 Please see [examples.php](examples.php) and [example-static.php](examples-static.php) for working examples.
 
-#Contributors:
+# Contributors:
 - [Sallar Kaboli](http://sallar.me)  
 - [Omid Pilevar](http://pilevar.ir)
 - [Afshin Mehrabani](http://afshinm.name)  
 - [Amir Latifi](http://amiir.me)
 - [Ruhollah Namjoo](https://github.com/namjoo)
 
-##License
+## License
 jDateTime was created by [Sallar Kaboli](http://sallar.me) and released under the [MIT License](http://opensource.org/licenses/mit-license.php).
 
 Copyright (C) 2016 [Sallar Kaboli](http://sallar.me)  
@@ -90,6 +90,6 @@ Copyright (C) 2000  Roozbeh Pournader and Mohammad Toossi
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
 
-#Resources
+# Resources
 - [List of supported timezones](http://www.php.net/manual/en/timezones.php)  
 - [Documentation and Instructions in Persian](http://sallar.me/farsi/projects/jdatetime/)  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
