### PR TITLE
Update jdatetime.class.php

### DIFF
--- a/jdatetime.class.php
+++ b/jdatetime.class.php
@@ -464,7 +464,7 @@ class jDateTime
         
         if ( is_string($timestamp) )
         {
-            if( ctype_digit($timestamp) || ( $timestamp{0} == '-' && ctype_digit(substr($timestamp, 1)) ) )
+            if( ctype_digit($timestamp) || ( $timestamp[0] == '-' && ctype_digit(substr($timestamp, 1)) ) )
             {
                 $timestamp = (int)$timestamp;
             }


### PR DESCRIPTION
fix error "Array and string offset access syntax with curly braces is deprecated"